### PR TITLE
Allow Multikube to be run without JWT validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -13,8 +13,8 @@ Please provide the following information:
 
 **- How to verify it**
 
-**- Description for the CHANGELOG**
 <!--
 Write a short (one line) summary that describes the changes in this
 pull request for inclusion in the CHANGELOG:
 -->
+**- Description for the CHANGELOG**

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -133,7 +133,7 @@ func WithLogging(c *Config, next http.Handler) http.Handler {
 	})
 }
 
-// WithJWT is a middleware that parses a JWT token from the requests and propagates 
+// WithJWT is a middleware that parses a JWT token from the requests and propagates
 // the request context with a claim value.
 func WithJWT(c *Config, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -7,11 +7,10 @@ import (
 	"fmt"
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/SermoDigital/jose/jws"
-	"github.com/SermoDigital/jose/jwt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	jwtv2 "gopkg.in/square/go-jose.v2/jwt"
+	"gopkg.in/square/go-jose.v2/jwt"
 	"log"
 	"math/big"
 	"net/http"
@@ -79,88 +78,6 @@ func init() {
 	prometheus.MustRegister(frontendGauge, frontendCounter, frontendHistogram, responseSize)
 }
 
-// newErrResponse marshals a string array into a json and writes to the provided responsewriter
-// func newErrResponse(w http.ResponseWriter, s int, e ...string) {
-// 	resp := &responseError{
-// 		Status: s,
-// 		Errs:   e,
-// 	}
-// 	b, err := json.Marshal(resp)
-// 	if err != nil {
-// 		b = []byte{}
-// 	}
-// 	w.Header().Set("Content-Type", "application/json")
-// 	http.Error(w, string(b), s)
-// }
-
-// func isValidWithX509Cert(c *Config, r *http.Request) (jwt.JWT, error) {
-
-// 	t, err := jws.ParseJWTFromRequest(r)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	if t == nil {
-// 		return nil, fmt.Errorf("No token in request")
-// 	}
-
-// 	err = t.Validate(c.RS256PublicKey.PublicKey, crypto.SigningMethodRS256)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	return t, nil
-
-// }
-
-func isValidWithJWK(c *Config, r *http.Request) (jwt.JWT, error) {
-
-	t, err := jws.ParseJWTFromRequest(r)
-	if err != nil {
-		return nil, err
-	}
-
-	raw := string(getTokenFromRequest(r))
-	tok, err := jwtv2.ParseSigned(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	// Try to find a JWK using the kid
-	kid := tok.Headers[0].KeyID
-	jwk := c.JWKS.Find(kid)
-	if jwk == nil {
-		return nil, fmt.Errorf("%s", "Key ID invalid")
-	}
-	if jwk.Kty != "RSA" {
-		return nil, fmt.Errorf("Invalid key type. Expected 'RSA' got '%s'", jwk.Kty)
-	}
-
-	// decode the base64 bytes for n
-	nb, err := base64.RawURLEncoding.DecodeString(jwk.N)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if E is big-endian int
-	if jwk.E != "AQAB" && jwk.E != "AAEAAQ" {
-		return nil, fmt.Errorf("Expected E to be one of 'AQAB' and 'AAEAAQ' but got '%s'", jwk.E)
-	}
-
-	pk := &rsa.PublicKey{
-		N: new(big.Int).SetBytes(nb),
-		E: 65537,
-	}
-
-	err = t.Validate(pk, crypto.SigningMethodRS256)
-	if err != nil {
-		return nil, err
-	}
-
-	return t, nil
-
-}
-
 // getTokenFromRequest returns a []byte representation of JWT from an HTTP Authorization Bearer header
 func getTokenFromRequest(req *http.Request) []byte {
 	if ah := req.Header.Get("Authorization"); len(ah) > 7 && strings.EqualFold(ah[0:7], "BEARER ") {
@@ -216,7 +133,8 @@ func WithLogging(c *Config, next http.Handler) http.Handler {
 	})
 }
 
-//
+// WithJWT is a middleware that parses a JWT token from the requests and propagates 
+// the request context with a claim value.
 func WithJWT(c *Config, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -246,6 +164,8 @@ func WithJWT(c *Config, next http.Handler) http.Handler {
 	})
 }
 
+// WithX509Validation is a middleware that validates a JWT token in the http request using RS256 signing method.
+// It will do so using a x509 certificate provided in c
 func WithX509Validation(c *Config, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -279,23 +199,65 @@ func WithX509Validation(c *Config, next http.Handler) http.Handler {
 	})
 }
 
-// WithRS256Validation validates a JWT token in the http request by parsing using RS256 signing method.
-// It will validate the JWT using a x509 public key or using Json Web Key from an OpenID Connect provider.
-// WithRS256Validation will validate the request only if one of the two methods considers the request to be valid.
-// If both fail, a 401 is returned to the client. If both methods validates successfully, x509 signed JWT's takes priority.
+// WithJWKValidation is a middleware that validates a JWT token in the http request using RS256 signing method.
+// It will do so using a JWK (Json Web Key) provided in c
 func WithJWKValidation(c *Config, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		// Validate the JWT in the request using both JWK's and x509 public certiticate
-		t, err := isValidWithJWK(c, r)
-
-		// Request is unauthorized if both return errors
+		t, err := jws.ParseJWTFromRequest(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 
-		// Set context
+		raw := string(getTokenFromRequest(r))
+		tok, err := jwt.ParseSigned(raw)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		// Try to find a JWK using the kid
+		kid := tok.Headers[0].KeyID
+		jwk := c.JWKS.Find(kid)
+		if jwk == nil {
+			http.Error(w, "key id invalid", http.StatusUnauthorized)
+			return
+		}
+		if jwk.Kty != "RSA" {
+			http.Error(w, fmt.Sprintf("Invalid key type. Expected 'RSA' got '%s'", jwk.Kty), http.StatusUnauthorized)
+			return
+		}
+
+		// decode the base64 bytes for n
+		nb, err := base64.RawURLEncoding.DecodeString(jwk.N)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		// Check if E is big-endian int
+		if jwk.E != "AQAB" && jwk.E != "AAEAAQ" {
+			http.Error(w, fmt.Sprintf("Expected E to be one of 'AQAB' and 'AAEAAQ' but got '%s'", jwk.E), http.StatusUnauthorized)
+			return
+		}
+
+		pk := &rsa.PublicKey{
+			N: new(big.Int).SetBytes(nb),
+			E: 65537,
+		}
+
+		err = t.Validate(pk, crypto.SigningMethodRS256)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
 		username, ok := t.Claims().Get(c.OIDCUsernameClaim).(string)
 		if !ok {
 			username = ""

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const (
@@ -31,7 +32,7 @@ type Proxy struct {
 	tlsconfigs map[string]*tls.Config
 }
 
-// NewProxy crerates a new Proxy and initialises router and configuration
+// NewProxy creates a new Proxy and initialises router and configuration
 func NewProxy() *Proxy {
 	return &Proxy{
 		transports: make(map[string]http.RoundTripper),
@@ -40,11 +41,16 @@ func NewProxy() *Proxy {
 }
 
 // NewProxyFrom creates an instance of Proxy
-func NewProxyFrom(c *Config, kc *api.Config) *Proxy {
+func NewProxyFrom(kc *api.Config) *Proxy {
 	p := NewProxy()
-	p.Config = c
 	p.KubeConfig = kc
-
+	p.Config = &Config{
+		OIDCIssuerURL:     "",
+		OIDCPollInterval:  time.Second * 2,
+		OIDCUsernameClaim: "sub",
+		RS256PublicKey:    &x509.Certificate{},
+		JWKS:              &JWKS{},
+	}
 	return p
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -40,7 +40,7 @@ var kubeConf *api.Config = &api.Config{
 
 // Just creates a new proxy instance
 func TestProxyNewProxy(t *testing.T) {
-	p := NewProxyFrom(config, kubeConf)
+	p := NewProxyFrom(kubeConf)
 	server := p.KubeConfig.Clusters[name].Server
 	if server != defServer {
 		t.Fatalf("Expected config cluster to be %s, got %s", defServer, server)


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Multikube should support passthrough of authentication credentials from the client if it is not configured with an OIDC provider or a x509 signer. This way a user can get started quickly and use Multikube as a router/proxy but without the validation capabilities.

**- How I did it**
* Added new Middleware `proxy.WithJWT`. Is only added to the proxy handler chain if flag `--oidc-issuer-url` is provided
* Added new Middleware `proxy.WithX509Validation`. Is only added to the proxy handler chain if flag `--rs256-public-key` is provided
* Removed middleware `proxy.WithRS256Validation`

**- How to verify it**
Run Multikube with each flag and once without any flag , and make requests.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Added support for running Multikube without JWT validation