### PR TITLE
Parse OIDC Issuer URL

### DIFF
--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -5,10 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
+	"path"
 	"time"
 )
 
@@ -82,8 +83,15 @@ func getKeys(u string, ca *x509.Certificate, i bool) (*JWKS, error) {
 // Accepts a trusted CA certificate as well as a bool to skip tls verification
 func getWellKnown(u string, ca *x509.Certificate, i bool) (*openIDConfiguration, error) {
 
-	wellKnownURL := fmt.Sprintf("%s/%s", u, "/.well-known/openid-configuration")
-	req, err := http.NewRequest("GET", wellKnownURL, nil)
+	ul, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	ul.Path = path.Join(ul.Path, ".well-known/openid-configuration")
+
+	//wellKnownURL := fmt.Sprintf("%s/%s", u, "/.well-known/openid-configuration")
+	req, err := http.NewRequest("GET", ul.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a bug where oidc issuer url would be incorrectly parsed 

**- How I did it**
Use of `path.Join()`

**- How to verify it**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Fixed OIDC provider discovery URL from being incorrectly parsed