### PR TITLE
Improved logging with `WithLogging` middleware

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/amimof/multikube/pkg/cache"
 	"golang.org/x/net/http/httpproxy"
 	"io/ioutil"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -84,7 +85,6 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		panic(err)
-		//return
 	}
 
 	if p.tlsconfigs[opts.ctx] == nil {
@@ -115,6 +115,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.transports[opts.ctx] == nil {
 		p.transports[opts.ctx] = &Transport{
 			TLSClientConfig: tlsConfig,
+			Cache:           cache.New(),
 		}
 	}
 

--- a/pkg/proxy/transport.go
+++ b/pkg/proxy/transport.go
@@ -74,11 +74,6 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		),
 	)
 
-	// Initialize the cache
-	if t.Cache == nil {
-		t.Cache = cache.New()
-	}
-
 	// Either return a response from the cache or from a real request
 	item := t.Cache.Get(req.URL.String())
 	if item != nil && req.Method == http.MethodGet {
@@ -88,6 +83,9 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		if err != nil {
 			return nil, err
 		}
+
+		// Set header to inform about the cached response
+		res.Header.Set("Multikube-Cache", item.Age().String())
 
 	} else {
 


### PR DESCRIPTION
* `WithLogging` now also logs response length, response code and if the response is cached or not
* Also improved how the cache is initialised for the transport. It is no longer created per request-

<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* More log parameters output
* Improved cache initialisation

**- How I did it**
* improved internal responseWriter struct by adding additional field `length`. 
* added a simple "timer" to `WithLogging` that adds response time to the log output
* the transport cache is now created when the transport is created.

**- How to verify it**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Added additional fields to the response log; content length, response time and if the response is cached or not