### PR TITLE
Rewrite `Proxy` handler to make use of `httputil.ReverseProxy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2 // indirect
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/tylerb/graceful v1.2.15
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/rsa"
 	"encoding/base64"
@@ -13,10 +14,9 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 	"log"
 	"math/big"
+	"net"
 	"net/http"
 	"net/url"
-	"net"
-	"bufio"
 	"strings"
 	"time"
 )

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -15,6 +15,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"net"
+	"bufio"
 	"strings"
 	"time"
 )
@@ -89,13 +91,13 @@ func getTokenFromRequest(req *http.Request) []byte {
 }
 
 // WriteHeader sends and sets an HTTP response header with the provided
-// status code.
+// status code. Implements the http.ResponseWriter interface
 func (r *responseWriter) WriteHeader(statusCode int) {
 	r.status = statusCode
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 
-// Write
+// Write implements the http.ResponseWriter interface
 func (r *responseWriter) Write(b []byte) (int, error) {
 	if r.status == 0 {
 		r.status = 200
@@ -103,6 +105,14 @@ func (r *responseWriter) Write(b []byte) (int, error) {
 	n, err := r.ResponseWriter.Write(b)
 	r.length += n
 	return n, err
+}
+
+// Hijack implements the http.Hijacker interface
+func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if r.length < 0 {
+		r.length = 0
+	}
+	return r.ResponseWriter.(http.Hijacker).Hijack()
 }
 
 // WithEmpty is an empty handler that does nothing

--- a/pkg/proxy/middleware_test.go
+++ b/pkg/proxy/middleware_test.go
@@ -1,74 +1,159 @@
 package proxy
 
 import (
+	"github.com/SermoDigital/jose/crypto"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
-func testHandler(w http.ResponseWriter, r *http.Request) {
-	// A very simple health check.
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
+func TestMiddlewareWithCtxRoot(t *testing.T) {
+	assert := assert.New(t)
 
-	// In the future we could report back on the status of our DB, or our cache
-	// (e.g. Redis) by performing a simple PING, and include them in the response.
-	w.Write([]byte(`{"alive": true}`))
-}
+	p := New()
+	p.KubeConfig = kubeConf
+	m := p.Use(
+		WithJWT,
+		WithCtxRoot,
+	)
 
-func TestMiddleware(t *testing.T) {
+	req, err := http.NewRequest("GET", "/dev-cluster-1/api/v1/pods/default", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/", nil)
-	w := httptest.NewRecorder()
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbWlyQG1pZGRsZXdhcmUuc2UiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.nSyFTR7SZ95-pkt_PcjbmVX7rZDizLxONOnF9HWhBIe1R6ir-rrzmOaXjVxfdcVlBKEFE9bz6PJMwD8-tqsZUqlOeXSLNXXeCGhdmhluBJrJMi-Ewyzmvm7yJ2L8bVfhhBJ3z_PivSbxMKLpWz7VkbwaJrk8950QkQ5oB_CV0ysoppTybGzvU1e8tc5h5wRKimju3BA3mA5HxN8K7-2lM_JZ8cbxBToGMBMsHKSy4VXAxm-lmvSwletLXqdSlqDQZejjJYYGaPpvDih1voTJ_FJnYFzx_NWq5qN416IGJrr1RAe92B2gfRUmzftFMMw8NEYBLDNXgKx3d9OOO9xKi9DxZ9wkFrZlwNZBj-VPTgNt5zeNgME8CJqgxvCaESuDAMWkjnfdyhBYAu9uUvbRSjFowFdQFumnVlKNfAlhKOQFOZpifFIwRFYda8lzvlJv1CzHEt500HgL2qofoIOTzFQNeJ_XkOQvRBy4eBkwxKvbHlwUAObxzZrCBjaAeQRGrMU926zpujSFQ_9KzUqNsNrxJWkBybOFViQp5mMZGFIWJbdt_oiROwZLG-NDK2i932hepUfr0i52mrTX-M9vTwy4uQsiMh2eSI7Ntghw0_xgrqqp6HZON7RPdKo2ldC5_rt9TFKKmyXvhZFLgxwsm8bzvqlIbV4KwNbEZIhh-n0")
 
-	handler := http.HandlerFunc(testHandler)
-	handler.ServeHTTP(w, req)
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	m(nil, p).ServeHTTP(rr, req)
 
 	// Check the status code is what we expect.
-	if status := w.Code; status != http.StatusOK {
+	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-}
-
-// Test the logging middleware. Should print output to the console
-func TestMiddlewareWithLogging(t *testing.T) {
-	handler := WithLogging(nil, http.HandlerFunc(testHandler))
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/", nil)
-	w := httptest.NewRecorder()
-
-	handler.ServeHTTP(w, req)
-
-	// Check the status code is what we expect.
-	if status := w.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
-	}
 	// Check the response body is what we expect.
-	expected := `{"alive": true}`
-	if w.Body.String() != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v", w.Body.String(), expected)
-	}
+	expected := string(`{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":"","selfLink":""}}`)
+
+	assert.JSONEq(expected, rr.Body.String(), "Got unexpected response body")
 
 }
 
-// Test the empty middleware. Shouldn't do anything
-func TestMiddlewareWithEmpty(t *testing.T) {
-	handler := WithEmpty(nil, http.HandlerFunc(testHandler))
+func TestMiddlewareWithHeader(t *testing.T) {
+	assert := assert.New(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/", nil)
-	w := httptest.NewRecorder()
+	p := New()
+	p.KubeConfig = kubeConf
+	m := p.Use(
+		WithJWT,
+		WithHeader,
+	)
 
-	handler.ServeHTTP(w, req)
+	req, err := http.NewRequest("GET", "/api/v1/pods/default", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+
+	req.Header.Set("Multikube-Context", "dev-cluster-1")
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbWlyQG1pZGRsZXdhcmUuc2UiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.nSyFTR7SZ95-pkt_PcjbmVX7rZDizLxONOnF9HWhBIe1R6ir-rrzmOaXjVxfdcVlBKEFE9bz6PJMwD8-tqsZUqlOeXSLNXXeCGhdmhluBJrJMi-Ewyzmvm7yJ2L8bVfhhBJ3z_PivSbxMKLpWz7VkbwaJrk8950QkQ5oB_CV0ysoppTybGzvU1e8tc5h5wRKimju3BA3mA5HxN8K7-2lM_JZ8cbxBToGMBMsHKSy4VXAxm-lmvSwletLXqdSlqDQZejjJYYGaPpvDih1voTJ_FJnYFzx_NWq5qN416IGJrr1RAe92B2gfRUmzftFMMw8NEYBLDNXgKx3d9OOO9xKi9DxZ9wkFrZlwNZBj-VPTgNt5zeNgME8CJqgxvCaESuDAMWkjnfdyhBYAu9uUvbRSjFowFdQFumnVlKNfAlhKOQFOZpifFIwRFYda8lzvlJv1CzHEt500HgL2qofoIOTzFQNeJ_XkOQvRBy4eBkwxKvbHlwUAObxzZrCBjaAeQRGrMU926zpujSFQ_9KzUqNsNrxJWkBybOFViQp5mMZGFIWJbdt_oiROwZLG-NDK2i932hepUfr0i52mrTX-M9vTwy4uQsiMh2eSI7Ntghw0_xgrqqp6HZON7RPdKo2ldC5_rt9TFKKmyXvhZFLgxwsm8bzvqlIbV4KwNbEZIhh-n0")
+
+	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+	// directly and pass in our Request and ResponseRecorder.
+	m(nil, p).ServeHTTP(rr, req)
 
 	// Check the status code is what we expect.
-	if status := w.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("Received status code '%d'. Response: '%s'", status, rr.Body.String())
 	}
+
 	// Check the response body is what we expect.
-	expected := `{"alive": true}`
-	if w.Body.String() != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v", w.Body.String(), expected)
+	expected := string(`{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":"","selfLink":""}}`)
+	assert.JSONEq(expected, rr.Body.String(), "Got unexpected response body")
+
+}
+
+var validRS256pubkey = []byte(`-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwTlp6YkFJlrhSJ7ukHJv
+wNe4+uUdTsizGK1u8Dh58EKpJkR9GrGLaB3LABC+CJpheBc5JU+Hd4UglEWIEFHK
+LSAEnsGXhl7bnuNeXxzBBM3LHTRfxQe/2rj69xuW7vbZ8pbhZ1+FVsxkznm28u6F
+zddAq2gLHCa0+Tc/IqqVTHx102fqzmOFMwLRHzTxoXaAx1uoRkngRK+8N3btWpQd
+hz1vHNPa1+6shuhPILpgGhcyGVsiLO3v4ZUdVZTw71295wTtPCLxoM/9F3o4VaRg
+dcrn9jTEUH/2uGgLNMlfpkbZaPk7p1GGaGjgaTZmFs25DurJjOADuNhiT+LXDLgo
+O6PIgIBlU6CUwcs7x9TZ1N7bqpWUOOVvIyZ65UNFIbExlAJPNENOer7voG+FJJ8W
+LYqmW/xGWG8sDsFZjHSpGaNq1do8eWa6y1X3eZfK7hmYWWxHDG4+0Rfcuf5lIUGq
+ChD6j7cVfJf4qRJNxHSccemM8H97MYKuHPTQM0NZruUPDDpKbwelVzglBT5PgNuv
+adPggesVbCunCIMggg2Wq47i551A+7Rb3Dki7FzjrHKiuv5CL+oGgxSN8jmCZXfc
+jIvzLIFNEY7lxHTyccY/YNgjNEMyUeu+9qI1sy5sAoco9HSncQIrVSD+VXtIhB4n
+rL/XzEalgKsZo5Z0rBmo7ycCAwEAAQ==
+-----END PUBLIC KEY-----`)
+
+var invalidRS256pubkey = []byte(`-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21sntvLQsX8p+E7uwJLM
+MCyJaMn21rR8Bb2LttyZMt94xV7YKBuWKO1Y+9Qzy316qKdGYrMHSTKreear+g4B
+QBYvkom4vPReMZH+BW6sYavTyNqt0Akm+PmH/E8qRDIpvkXbA4goy/tM9Bychaxm
+JAKtPIVoXvdpbfmYML5XX5pC8zJuZTCMfu36ncgV+Bxyzf859uIe4oqxVxXMsbKk
+wK81kodtG5WeMYcO8xtHMfwtI97IMOlvN/3VUZMWc/wpiOE3CutkaQc/wdRQtQks
+fFGXHj1zUev2eB4zO+m7ks4zMCL58jIE1s1LlpE/lcEscIc8jPV6WGHuuUCnL7lB
+8wIDAQAB
+-----END PUBLIC KEY-----`)
+
+func TestMiddlewareWithRS256Validation(t *testing.T) {
+	assert := assert.New(t)
+	req, err := http.NewRequest("GET", "/dev-cluster-1/api/v1/pods/default", nil)
+	if err != nil {
+		t.Fatal(err)
 	}
+	rr := httptest.NewRecorder()
+
+	req.Header.Set("Multikube-Context", "dev-cluster-1")
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbWlyQG1pZGRsZXdhcmUuc2UiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.nSyFTR7SZ95-pkt_PcjbmVX7rZDizLxONOnF9HWhBIe1R6ir-rrzmOaXjVxfdcVlBKEFE9bz6PJMwD8-tqsZUqlOeXSLNXXeCGhdmhluBJrJMi-Ewyzmvm7yJ2L8bVfhhBJ3z_PivSbxMKLpWz7VkbwaJrk8950QkQ5oB_CV0ysoppTybGzvU1e8tc5h5wRKimju3BA3mA5HxN8K7-2lM_JZ8cbxBToGMBMsHKSy4VXAxm-lmvSwletLXqdSlqDQZejjJYYGaPpvDih1voTJ_FJnYFzx_NWq5qN416IGJrr1RAe92B2gfRUmzftFMMw8NEYBLDNXgKx3d9OOO9xKi9DxZ9wkFrZlwNZBj-VPTgNt5zeNgME8CJqgxvCaESuDAMWkjnfdyhBYAu9uUvbRSjFowFdQFumnVlKNfAlhKOQFOZpifFIwRFYda8lzvlJv1CzHEt500HgL2qofoIOTzFQNeJ_XkOQvRBy4eBkwxKvbHlwUAObxzZrCBjaAeQRGrMU926zpujSFQ_9KzUqNsNrxJWkBybOFViQp5mMZGFIWJbdt_oiROwZLG-NDK2i932hepUfr0i52mrTX-M9vTwy4uQsiMh2eSI7Ntghw0_xgrqqp6HZON7RPdKo2ldC5_rt9TFKKmyXvhZFLgxwsm8bzvqlIbV4KwNbEZIhh-n0")
+
+	p := New()
+	p.KubeConfig = kubeConf
+
+	// Test with a valid pub key
+	pubkey, err := crypto.ParseRSAPublicKeyFromPEM(validRS256pubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.RS256PublicKey = pubkey
+
+	p.Use(
+		WithJWT,
+		WithCtxRoot,
+		WithRS256Validation,
+	)(nil, p).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("Received status code '%d'. Response: '%s'", status, rr.Body.String())
+	}
+
+	expected := string(`{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":"","selfLink":""}}`)
+	assert.JSONEq(expected, rr.Body.String(), "Got unexpected response body")
+
+	// Test with an invalid pub key
+	rr = httptest.NewRecorder()
+	pubkey, err = crypto.ParseRSAPublicKeyFromPEM(invalidRS256pubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.RS256PublicKey = pubkey
+
+	p.Use(
+		WithJWT,
+		WithCtxRoot,
+		WithRS256Validation,
+	)(nil, p).ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Fatalf("Received status code '%d'. Response: '%s'", status, rr.Body.String())
+	}
+
+	expected = "crypto/rsa: verification error\n"
+	assert.Equal(expected, rr.Body.String(), "Got unexpected response body")
 
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -77,7 +77,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resCache = nil
 	}
 
-	// Create a transport that will be re-used for 
+	// Create a transport that will be re-used for
 	if p.transports[opts.ctx] == nil {
 		// Setup TLS config
 		tlsConfig, err := configureTLS(opts)


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

They way how multikube communicates with backends feels unstable and buggy. Mostly due to the fact that it uses our own `Request` type in combination with streamed data. These changes makes it so that Proxy uses `httputil.ReverseProxy` instead for communication with backends. 

**- What I did**
Replaced proxy implementation with `httputil.ReverseProxy` which is built in Golang

**- How I did it**
* The `Proxy` HTTP handler makes use of `httputil.ReverseProxy` instead of our own implementation
* Removed `Request` type (our HTTP client)
* Removed `tlsconfigs` on `Proxy` struct as this can be attached to `transports` directly
* Removed now obsolete internal functions such as `stream()` since all this will be handled by ReverseProxy instead

**- How to verify it**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Proxy implementation is now based on the built int type `httputil.ReverseProxy`