### PR TITLE
Fix go build ldflags variable interpolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ export CGO_ENABLED=0
 all: | $(BIN) ; $(info $(M) building executable to $(BUILDPATH)) @ ## Build program binary
 	$Q $(GO) build \
 		-tags release \
-		-ldflags '-X $(MODULE)/cmd.Version=$(VERSION) -X $(MODULE)/cmd.BuildDate=$(DATE)' \
+		-ldflags '-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH} -X main.GOVERSION=${GOVERSION}' \
 		-o $(BUILDPATH) cmd/multikube/main.go
 
 # Tools


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed so that ldflags variables are correctly interpolated duing build in Makefile

**- How I did it**
N/A

**- How to verify it**
 N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
N/A