### PR TITLE
Create transports during proxy initialisation

### DIFF
--- a/pkg/proxy/header_test.go
+++ b/pkg/proxy/header_test.go
@@ -10,8 +10,11 @@ import (
 func TestMiddlewareWithHeader(t *testing.T) {
 	assert := assert.New(t)
 
-	p := New().Use(WithHeader())
-	p.KubeConfig = kubeConf
+	p, err := New(kubeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Use(WithHeader())
 
 	req, err := http.NewRequest("GET", "/api/v1/pods/default", nil)
 	if err != nil {

--- a/pkg/proxy/jwt_test.go
+++ b/pkg/proxy/jwt_test.go
@@ -10,8 +10,11 @@ import (
 func TestMiddlewareJWT(t *testing.T) {
 	assert := assert.New(t)
 
-	p := New().Use(WithJWT())
-	p.KubeConfig = kubeConf
+	p, err := New(kubeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Use(WithJWT())
 
 	req, err := http.NewRequest("GET", "/dev-cluster-1/api/v1/pods/default", nil)
 	if err != nil {

--- a/pkg/proxy/metrics.go
+++ b/pkg/proxy/metrics.go
@@ -121,5 +121,6 @@ func init() {
 		rs256ReqsTotal,
 		rs256ReqsAuthorized,
 		rs256ReqsUnauthorized,
+		cacheTTL,
 	)
 }

--- a/pkg/proxy/rs256_test.go
+++ b/pkg/proxy/rs256_test.go
@@ -54,14 +54,17 @@ func TestMiddlewareWithRS256Validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := New().Use(
+	p, err := New(kubeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.Use(
 		WithJWT(),
 		WithRS256(RS256Config{
 			PublicKey: pubkey,
-		}))
-	p.KubeConfig = kubeConf
-
-	p.Chain().ServeHTTP(rr, req)
+		}),
+	).Chain().ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
 		t.Fatalf("Got status code %d. Expected: %d", status, http.StatusOK)
@@ -79,14 +82,17 @@ func TestMiddlewareWithRS256Validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p = New().Use(
+	p, err = New(kubeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.Use(
 		WithJWT(),
 		WithRS256(RS256Config{
 			PublicKey: pubkey,
-		}))
-	p.KubeConfig = kubeConf
-
-	p.Chain().ServeHTTP(rr, req)
+		}),
+	).Chain().ServeHTTP(rr, req)
 
 	assert.Equal(http.StatusUnauthorized, rr.Code, "Got unexpected status code")
 


### PR DESCRIPTION
Right now the transports to backends are created in the ServeHTTP method "on-the-fly". It's better to create transports when proxy is created so that they are already ready when requests are accepted.

<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Created metrics `multikube_build_info`
* Added a couple of tests
* `Proxy.KubeConfig` is now `Proxy.kubeConfig`
* Added pointer receiver `Proxy.CacheTTL` that loops over all transports and sets their cache's TTL value. 
* Removed field `Proxy.CacheTTL`

**- How I did it**
N/A

**- How to verify it**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Transports to backends are created during proxy creation